### PR TITLE
Improvment on `compute_branch_priority` function

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1,7 +1,6 @@
 use chrono::Utc;
 use indicatif::{ProgressBar, ProgressStyle};
 use octocrab::{Octocrab, Page};
-use std::collections::HashSet;
 use std::time::Duration;
 
 use crate::types::{
@@ -150,10 +149,7 @@ impl GitHubClient {
         };
 
         // Step 2: Build branch list with deduplication
-        let mut branches =
-            vec!["main".to_string(), "master".to_string(), default_branch];
-        let mut seen = HashSet::new();
-        branches.retain(|b| seen.insert(b.clone()));
+        let branches = compute_branch_priority(default_branch);
 
         // Step 3: Try fetching raw file from each branch
         let client = reqwest::Client::new();
@@ -231,13 +227,11 @@ impl WalletFetcher for GitHubClient {
 }
 
 // Small helper for testing branch priority logic deterministically without network
-#[allow(dead_code)]
 pub(crate) fn compute_branch_priority(default_branch: String) -> Vec<String> {
-    let mut branches =
-        vec!["main".to_string(), "master".to_string(), default_branch];
-    let mut seen = std::collections::HashSet::new();
-    branches.retain(|b| seen.insert(b.clone()));
-    branches
+    match default_branch.as_str() {
+        "main" | "master" => vec!["main".to_owned(), "master".to_owned()],
+        _ => vec!["main".to_owned(), "master".to_owned(), default_branch],
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I have no idea on why this original function was so overengineered, so it just fixes that, also uses this function instead of reimplementing it's logic in fetch_wallet_address