### PR TITLE
Remove `#[async_trait::async_trait]` attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1.47", features = ["full"] }
-async-trait = "0.1"
 
 [dev-dependencies]
 tempfile = "3.12"

--- a/src/github.rs
+++ b/src/github.rs
@@ -14,12 +14,11 @@ pub struct GitHubClient {
 
 // Trait to allow testing Wallet fetch logic without real network
 // Implemented by GitHubClient; tests can provide a mock implementation.
-#[async_trait::async_trait]
 pub trait WalletFetcher: Send + Sync {
-    async fn fetch_wallet_address(
+    fn fetch_wallet_address(
         &self,
         login: &str,
-    ) -> Result<Option<WalletFetchOutcome>>;
+    ) -> impl std::future::Future<Output = Result<Option<WalletFetchOutcome>>> + Send;
 }
 
 impl GitHubClient {
@@ -220,7 +219,6 @@ impl GitHubClient {
     }
 }
 
-#[async_trait::async_trait]
 impl WalletFetcher for GitHubClient {
     async fn fetch_wallet_address(
         &self,

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -100,7 +100,6 @@ mod tests {
         outcomes: Mutex<VecDeque<Option<WalletFetchOutcome>>>,
     }
 
-    #[async_trait::async_trait]
     impl WalletFetcher for MockFetcher {
         async fn fetch_wallet_address(
             &self,


### PR DESCRIPTION
It's not needed from some rust version anymore, tho this `impl Future` type is still needed if we want `Send` (we want)

While it sounds like more decorative change, this removes a one dependecy which improves compilation time 